### PR TITLE
Fix for item_id extraction for entities

### DIFF
--- a/kw_itemnames_entity.kw_itemnames.inc
+++ b/kw_itemnames_entity.kw_itemnames.inc
@@ -70,7 +70,7 @@ function kw_itemnames_entity_item_delete($entity_type, $entity_id) {
 }
 
 function kw_itemnames_entity_item_extract_id($entity_type, $entity) {
-  list(,$entity_id,) = entity_extract_ids($entity_type, $entity);
+  list($entity_id,,) = entity_extract_ids($entity_type, $entity);
   return $entity_id;
 }
 


### PR DESCRIPTION
The code in kw_itemnames_entity_item_extract_id uses the revision_id instead of the entity_id to determine the item_id. This fails for entities without revisions. We should use the entity_id instead.
